### PR TITLE
chore: add .gitattributes to ignore Python files in .agents/ for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore Python files in .agents/ for GitHub linguist language stats
+.agents/**/*.py linguist-vendored


### PR DESCRIPTION
This PR adds a .gitattributes file that marks all Python files in the .agents/ directory as linguist-vendored. This ensures GitHub language statistics ignore these files, keeping language stats accurate for the main codebase.\n\nCo-Authored-By: GitHub Copilot <noreply@github.com>