### PR TITLE
ci: Use `--shamefully-hoist` to address missing dependencies issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,9 +88,9 @@ jobs:
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
-      - run: rm -r -fo node_modules && pnpm install --prod
+      - run: rm -r -fo node_modules && pnpm install --prod --shamefully-hoist
         if: ${{ matrix.runs-on == 'windows-latest' }}
-      - run: rm -rf node_modules && pnpm install --prod
+      - run: rm -rf node_modules && pnpm install --prod --shamefully-hoist
         if: ${{ matrix.runs-on != 'windows-latest' }}
       - id: name
         shell: bash


### PR DESCRIPTION
Updated pnpm install command to use --shamefully-hoist option for better compatibility.