### PR TITLE
fix(preview): show metadata for unsupported files

### DIFF
--- a/src/components/FilePreview.tsx
+++ b/src/components/FilePreview.tsx
@@ -241,6 +241,11 @@ export const FilePreview = ({ bucket, file }: FilePreviewProps) => {
     <div className="preview-panel">
       <h3>{file.name}</h3>
       <p>No preview available for this file type.</p>
+      <PreviewMetadata
+        size={metadataSize}
+        lastModified={metadataLastModified}
+        contentType={metadataContentType}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Render file metadata in the fallback preview branch so selected files always show size, modified time, and type.

Co-Authored-By: GPT-5.3-Codex <noreply@agents.md>
